### PR TITLE
Fix text and image alignment on verification page

### DIFF
--- a/ShopIt/shopit update 2.md
+++ b/ShopIt/shopit update 2.md
@@ -1,0 +1,3 @@
+Fixed the size and alignment of text and images on the business verification page
+
+<img width="409" height="766" alt="image" src="https://github.com/user-attachments/assets/2fdafd92-0904-496a-a9c0-750a03283e2c" />


### PR DESCRIPTION
Adjusted text and image size and alignment on the business verification page.

<img width="424" height="781" alt="image" src="https://github.com/user-attachments/assets/2216f74c-9576-41db-a76f-6e5b74874393" />
